### PR TITLE
Fix link to "Layman's Guide"

### DIFF
--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -154,7 +154,7 @@ Here you can get the official standards which is hard to read:
 
 On the other end of the readability spectrum, here is a quick and sweet write up:
 
-* `A Layman's Guide to a Subset of ASN.1, BER, and DER <ftp://ftp.rsasecurity.com/pub/pkcs/ascii/layman.asc>`_ by Burton S. Kaliski
+* `A Layman's Guide to a Subset of ASN.1, BER, and DER <https://www.researchgate.net/publication/2820226_A_Layman's_Guide_to_a_Subset_of_ASN1_BER_and_DER>`_ by Burton S. Kaliski
 
 If you are working with ASN.1, we'd highly recommend reading a proper
 book on the subject.


### PR DESCRIPTION
The host ftp.rsasecurity.com does no longer resolve for me.

kk:~ kris$ host ftp.rsasecurity.com
Host ftp.rsasecurity.com not found: 3(NXDOMAIN)

FTP Links are no longer supported directly in many browsers.

I replace the link to the text to a PDF version of the document in question, hosted by researchgate.net. This is supposed to be a stable URL, and the formatted document is probably easier to read.